### PR TITLE
Add tiny-secp256k1/rfc6979 for babel

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -179,6 +179,7 @@ module.exports = {
               ...[
                 'bitcoinjs-lib',
                 'tiny-secp256k1/ecurve',
+                'tiny-secp256k1/rfc6979',
                 'base64url/dist/base64url',
                 'base64url/dist/pad-string',
                 'bip32'


### PR DESCRIPTION
`yarn build` in my project failed with 

      Failed to minify the code from this file:
       ./node_modules/tiny-secp256k1/rfc6979.js:11

So, I think we need to add that.